### PR TITLE
Implement plugin manager UI

### DIFF
--- a/app_new_ui.py
+++ b/app_new_ui.py
@@ -392,6 +392,74 @@ class UserManagementDialog(QDialog):
                 QMessageBox.critical(self, "Ошибка", f"Не удалось удалить пользователя '{username}'.")
 
 
+class PluginManagerDialog(QDialog):
+    def __init__(self, plugin_manager: PluginManager, parent=None):
+        super().__init__(parent)
+        self.plugin_manager = plugin_manager
+        self.setWindowTitle("Менеджер плагинов")
+        self.setMinimumSize(400, 300)
+
+        if not self.plugin_manager.plugins:
+            load_messages = self.plugin_manager.load_plugins()
+            if load_messages:
+                QMessageBox.information(self, "Загрузка плагинов", "\n".join(load_messages))
+
+        layout = QVBoxLayout(self)
+        self.list_widget = QListWidget()
+        layout.addWidget(self.list_widget)
+
+        btn_layout = QHBoxLayout()
+        self.reload_btn = QPushButton("Перезагрузить")
+        self.deactivate_btn = QPushButton("Деактивировать")
+        close_btn = QPushButton("Закрыть")
+
+        self.reload_btn.clicked.connect(self.reload_plugins)
+        self.deactivate_btn.clicked.connect(self.deactivate_selected)
+        close_btn.clicked.connect(self.accept)
+
+        btn_layout.addWidget(self.reload_btn)
+        btn_layout.addWidget(self.deactivate_btn)
+        btn_layout.addStretch()
+        btn_layout.addWidget(close_btn)
+        layout.addLayout(btn_layout)
+
+        self.populate_list()
+
+    def populate_list(self):
+        self.list_widget.clear()
+        if not self.plugin_manager.plugins:
+            self.list_widget.addItem("(нет активных плагинов)")
+            self.list_widget.setEnabled(False)
+            self.deactivate_btn.setEnabled(False)
+        else:
+            self.list_widget.setEnabled(True)
+            self.deactivate_btn.setEnabled(True)
+            for plugin in self.plugin_manager.plugins:
+                self.list_widget.addItem(plugin.__class__.__name__)
+
+    def reload_plugins(self):
+        messages = self.plugin_manager.reload_plugins()
+        self.populate_list()
+        QMessageBox.information(self, "Результат", "\n".join(messages))
+
+    def deactivate_selected(self):
+        items = self.list_widget.selectedItems()
+        if not items:
+            QMessageBox.warning(self, "Ошибка", "Выберите плагин для деактивации.")
+            return
+        for item in items:
+            name = item.text()
+            for plugin in list(self.plugin_manager.plugins):
+                if plugin.__class__.__name__ == name:
+                    try:
+                        plugin.deactivate()
+                        self.plugin_manager.plugins.remove(plugin)
+                        QMessageBox.information(self, "Готово", f"Плагин '{name}' деактивирован.")
+                    except Exception as e:
+                        QMessageBox.critical(self, "Ошибка", f"Не удалось деактивировать '{name}': {e}")
+        self.populate_list()
+
+
 class InfoLabel(QLabel):
     def __init__(self, text="", parent=None):
         super().__init__(text, parent)
@@ -470,7 +538,8 @@ class MainWindow(QMainWindow):
         file_menu.addAction(exit_action)
 
         tools_menu = menu_bar.addMenu("Инструменты")
-        plugins_action = QAction(QIcon.fromTheme("system-software-install"), "Менеджер плагинов (WIP)", self)
+        plugins_action = QAction(QIcon.fromTheme("system-software-install"), "Менеджер плагинов", self)
+        plugins_action.triggered.connect(self.open_plugin_manager)
         tools_menu.addAction(plugins_action)
 
         if self.user_role == Role.ADMIN:
@@ -486,6 +555,10 @@ class MainWindow(QMainWindow):
 
     def open_user_management(self):
         dialog = UserManagementDialog(self.auth_manager, self.username, self)
+        dialog.exec_()
+
+    def open_plugin_manager(self):
+        dialog = PluginManagerDialog(self.plugin_manager, self)
         dialog.exec_()
 
     def show_about_dialog(self):

--- a/plugin_api.py
+++ b/plugin_api.py
@@ -51,11 +51,14 @@ class PluginManager:
             os.makedirs(self.plugin_dir)
             print(f"Plugin directory '{self.plugin_dir}' created.")
 
-    def load_plugins(self):
+    def load_plugins(self) -> List[str]:
         """
         Сканирует директорию плагинов, импортирует их и активирует.
+
+        Returns:
+            Список сообщений о ходе загрузки.
         """
-        print(f"Loading plugins from '{self.plugin_dir}'...")
+        messages = [f"Loading plugins from '{self.plugin_dir}'..."]
         for filename in os.listdir(self.plugin_dir):
             if filename.endswith(".py") and not filename.startswith("__"):
                 module_name = f"{self.plugin_dir}.{filename[:-3]}"
@@ -67,25 +70,38 @@ class PluginManager:
                             plugin_instance = item(self.app_context)
                             self.plugins.append(plugin_instance)
                             plugin_instance.activate()
-                            print(f"Plugin '{item.__name__}' activated.")
+                            msg = f"Plugin '{item.__name__}' activated."
+                            messages.append(msg)
+                            print(msg)
                 except Exception as e:
-                    print(f"Failed to load or activate plugin from '{filename}': {e}")
-        print(f"Finished loading plugins. Total active: {len(self.plugins)}.")
+                    msg = f"Failed to load or activate plugin from '{filename}': {e}"
+                    messages.append(msg)
+                    print(msg)
+        summary = f"Finished loading plugins. Total active: {len(self.plugins)}."
+        messages.append(summary)
+        print(summary)
+        return messages
 
-    def reload_plugins(self):
+    def reload_plugins(self) -> List[str]:
         """
         Деактивирует все текущие плагины и загружает их заново.
+
+        Returns:
+            Список сообщений о ходе перезагрузки.
         """
-        print("Reloading all plugins...")
-        # Деактивация
+        messages = ["Reloading all plugins..."]
         for plugin in self.plugins:
             try:
                 plugin.deactivate()
-                print(f"Plugin '{plugin.__class__.__name__}' deactivated.")
+                msg = f"Plugin '{plugin.__class__.__name__}' deactivated."
+                messages.append(msg)
+                print(msg)
             except Exception as e:
-                print(f"Error deactivating plugin '{plugin.__class__.__name__}': {e}")
-        
+                msg = f"Error deactivating plugin '{plugin.__class__.__name__}': {e}"
+                messages.append(msg)
+                print(msg)
+
         self.plugins.clear()
-        
-        # Загрузка заново
-        self.load_plugins()
+
+        messages.extend(self.load_plugins())
+        return messages


### PR DESCRIPTION
## Summary
- add PluginManager.load_plugins and reload_plugins message reporting
- create PluginManagerDialog with plugin list management
- hook Plugin Manager dialog into the Tools menu

## Testing
- `python -m py_compile plugin_api.py app_new_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_68645ef4610c8327a2790d93f5cbb42a